### PR TITLE
Change default `controls` value to `2`

### DIFF
--- a/utube.js
+++ b/utube.js
@@ -32,7 +32,7 @@ UTube.prototype.options = {
     autohide: 1,
     autoplay: 1,
     color: 'white',
-    controls: 1,
+    controls: 2,
     cc_load_policy: 0,
     disablekb: 0,
     enablejsapi: 1,


### PR DESCRIPTION
From the docs: Note: The parameter values `1` and `2` are intended to provide an identical user experience, but `controls=2` provides a performance improvement over `controls=1` for IFrame embeds. 

https://developers.google.com/youtube/player_parameters?playerVersion=HTML5#controls